### PR TITLE
Support for several metadata with the same key

### DIFF
--- a/plyara/interp.py
+++ b/plyara/interp.py
@@ -171,6 +171,8 @@ tokens = [
   'STRINGCOUNT',
   'GREATERTHAN',
   'LESSTHAN',
+  'GREATEREQUAL',
+  'LESSEQUAL',
   'PERIOD',
   'COLON',
   'STAR',
@@ -239,6 +241,8 @@ t_FORWARDSLASH = r'/'
 t_COMMA = r','
 t_GREATERTHAN = r'>'
 t_LESSTHAN = r'<'
+t_GREATEREQUAL = r'>='
+t_LESSEQUAL = r'<='
 t_PERIOD = r'\.'
 t_COLON = r':'
 t_STAR = r'\*'
@@ -308,22 +312,22 @@ def t_REXSTRING(t):
   return t
 
 def t_STRINGNAME(t):
-  r'\$[0-9a-zA-Z\-_]*'
+  r'\$[0-9a-zA-Z\-_*]*'
   t.value = t.value
   return t
 
 def t_STRINGNAME_ARRAY(t):
-  r'@[0-9a-zA-Z\-_]*'
+  r'@[0-9a-zA-Z\-_*]*'
   t.value = t.value
   return t
 
 def t_NUM(t):
-  r'\d+|0x\d+'
+  r'\d+(\.\d+)?|0x\d+'
   t.value = t.value
   return t
 
 def t_ID(t):
-  r'[a-zA-Z_]{1}[a-zA-Z_0-9]*'
+  r'[a-zA-Z_]{1}[a-zA-Z_0-9.]*'
   t.type = reserved.get(t.value, 'ID')  # Check for reserved words
   return t
 
@@ -498,6 +502,8 @@ def p_condition(p):
           | COMMA
           | GREATERTHAN
           | LESSTHAN
+          | GREATEREQUAL
+          | LESSEQUAL
           | PERIOD
           | COLON
           | STAR

--- a/plyara/interp.py
+++ b/plyara/interp.py
@@ -65,7 +65,13 @@ class ParserInterpreter:
       if "metadata" not in self.currentRule:
         self.currentRule["metadata"] = {elementValue[0]: elementValue[1]}
       else:
-        self.currentRule["metadata"][elementValue[0]] = elementValue[1]
+        if elementValue[0] not in self.currentRule["metadata"]:
+          self.currentRule["metadata"][elementValue[0]] = elementValue[1]
+        else:
+          if isinstance( self.currentRule["metadata"][elementValue[0]], list):
+            self.currentRule["metadata"][elementValue[0]].append( elementValue[1] )
+          else:
+            self.currentRule["metadata"][elementValue[0]] = [ self.currentRule["metadata"][elementValue[0]], elementValue[1] ]
 
     elif elementType == ElementTypes.STRINGS_KEY_VALUE:
       string_dict = {'name': elementValue[0], 'value': elementValue[1]}


### PR DESCRIPTION
I have found that if we have several metadata with the same key (for example, several links), plyara overwrites older values, so we only keep the last value.

I have added a couple of lines of code that creates a list of values when we are in this situation. I think this could be useful for other people.
