### PR TITLE
Bugfix - Conditions can contain regex strings

### DIFF
--- a/plyara/interp.py
+++ b/plyara/interp.py
@@ -563,7 +563,8 @@ def p_condition(p):
           | UINT32BE
           | STRINGNAME
           | STRINGNAME_ARRAY
-          | STRINGCOUNT'''
+          | STRINGCOUNT
+          | REXSTRING'''
 
   parserInterpreter.printDebugMessage('...matched a term: ' + p[1])
   parserInterpreter.addElement(ElementTypes.TERM, p[1])


### PR DESCRIPTION
Example: 
```condition: all of them and not file_name matches /CA.dll/```
See: https://yara.readthedocs.io/en/v3.5.0/writingrules.html#external-variables